### PR TITLE
Changed plugin id to work with remotes

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.audio.ukigumo_soundcloud" name="Ukigumo SoundCloud" version="0.0.1" provider-name="ukigumo">
+<addon id="plugin.audio.soundcloud" name="Ukigumo SoundCloud" version="0.0.1" provider-name="ukigumo">
 	<requires>
 		<import addon="xbmc.python" version="2.14.0"/>
 	</requires>


### PR DESCRIPTION
Changed ID back to plugin.audio.soundcloud to enable Share -> Play on Kodi on Android with Yatse Remote, without beeig asked for installation of soundcloud plugin