### PR TITLE
Minor convenience changes...

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.audio.soundcloud" name="Ukigumo SoundCloud" version="0.0.1" provider-name="ukigumo">
+<addon id="plugin.audio.soundcloud" name="SoundCloud" version="2.0.6-001" provider-name="ukigumo">
 	<requires>
 		<import addon="xbmc.python" version="2.14.0"/>
 	</requires>
@@ -26,6 +26,6 @@
 		<forum>http://forum.kodi.tv/showthread.php?tid=206635</forum>
 		<website>www.soundcloud.com</website>
 		<email>kodi at bromix dot org</email>
-		<source>https://github.com/bromix/plugin.audio.soundcloud</source>
+		<source>https://github.com/ukigumoh/plugin.audio.soundcloud</source>
 	</extension>
 </addon>


### PR DESCRIPTION
Renamed to "Soundcloud" for more aesthetically pleasing skin shortcut widgets. Changed version number to 2.0.6-001 so that it doesn't autoupdate to the broken version upon installing.
Changed source github to ukigumoh's repo.
(Retrieved v2.0.6 to see whether we missed any changes since base was 2.0.5.)